### PR TITLE
add travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: ruby
+rvm: 2.4.1
+before_script: gem install awesome_bot
+script: awesome_bot README.md --allow-redirect --allow-dupe
+notifications:
+  email: false

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License MIT">
   </a>
+  <a href="https://travis-ci.org/leonardomso/33-js-concepts">
+    <img src="https://travis-ci.org/leonardomso/33-js-concepts.svg?branch=master" alt="Build Status">
+  </a>
 </p>
 
 ## Introduction


### PR DESCRIPTION
Use travis CI to check the links in README, and show the build status.
May need to open CI in [travis](https://travis-ci.org)