### PR TITLE
fix build status img source

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@
     <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License MIT">
   </a>
   <a href="https://travis-ci.org/leonardomso/33-js-concepts">
-    <img src="https://travis-ci.org/leonardomso/33-js-concepts.svg?branch=master" alt="Build Status">
+    <img src="https://travis-ci.com/leonardomso/33-js-concepts.svg?branch=master" alt="Build Status">
   </a>
 </p>
 


### PR DESCRIPTION
Sorry for the wrong build status image source link from #35 😅.

Fixed it using `travis-ci.com` instead of `travis-ci.org`.