### PR TITLE
fix travis ci

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: ruby
 rvm: 2.4.1
 before_script: gem install awesome_bot
-script: awesome_bot README.md --allow-redirect --allow-dupe
+script: awesome_bot README.md --allow-redirect --allow-dupe --allow 999
 notifications:
   email: false

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="https://opensource.org/licenses/MIT">
     <img src="https://img.shields.io/badge/license-MIT-blue.svg?style=flat-square" alt="License MIT">
   </a>
-  <a href="https://travis-ci.org/leonardomso/33-js-concepts">
+  <a href="https://travis-ci.com/leonardomso/33-js-concepts">
     <img src="https://travis-ci.com/leonardomso/33-js-concepts.svg?branch=master" alt="Build Status">
   </a>
 </p>


### PR DESCRIPTION
Fix travis CI again🤕.

Check linkedin.com failed sometimes since linkedin  filters requests based on the user-agent and return `999`, so simply ignore it.
![screen shot 2018-10-24 at 1 29 14 pm](https://user-images.githubusercontent.com/23313266/47408184-d5fa1900-d790-11e8-83d8-ec9aec8a4973.png)

Ref: [stackoverflow](https://stackoverflow.com/questions/27231113/999-error-code-on-head-request-to-linkedin)