### PR TITLE
Removes duplicate link

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,7 +1029,6 @@ All the translations for this repo will be listed below:
  * 📜 [Clean Code concepts adapted for JavaScript — Ryan McDermott](https://github.com/ryanmcdermott/clean-code-javascript)
  * 📜 [JavaScript Clean Coding Best Practices — András Tóth](https://blog.risingstack.com/javascript-clean-coding-best-practices-node-js-at-scale/)
  * 📜 [Function parameters in JavaScript Clean Code — Kevin Peters](https://medium.com/@kevin_peters/function-parameters-in-javascript-clean-code-4caac109159b)
- * 📜 [Clean Code JavaScript — Sarah Drasner](https://css-tricks.com/clean-code-javascript/)
  * 📜 [Keeping your code clean — Samuel James](https://codeburst.io/keeping-your-code-clean-d30bcffd1a10)
  * 📜 [Best Practices for Using Modern JavaScript Syntax — M. David Green](https://www.sitepoint.com/modern-javascript-best-practices/)
  * 📜 [best practices for cross node/web development - Jimmy Wärting](https://github.com/cross-js/cross-js)


### PR DESCRIPTION
[Clean Code JavaScript — Sarah Drasner] - https://css-tricks.com/clean-code-javascript/ is a page with just a direct link to https://github.com/ryanmcdermott/clean-code-javascript that already exists in the list of useful articles for Clean Code Concepts