### PR TITLE
Add Clean Coder Blog to clean code resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -1142,6 +1142,7 @@ All the translations for this repo will be listed below:
 - 📜 [Practical Ways to Write Better JavaScript - Ryland G](https://dev.to/taillogs/practical-ways-to-write-better-javascript-26d4)
 - 📜 [The Must-Know Clean Code Principles - Kesk on Medium](https://medium.com/swlh/the-must-know-clean-code-principles-1371a14a2e75)
 - 📜 [The Clean Code Book - Robert C Martin](https://www.amazon.com/Clean-Code-Handbook-Software-Craftsmanship/dp/0132350882/)
+- 📜 [The Clean Code Blog - Robert C Martin](https://blog.cleancoder.com/)
 
 ### Videos
 


### PR DESCRIPTION
Adds Robert Martin’s Clean Code blog to the list of clean code resources