### PR TITLE
fix: removed inactive links and added a new Big O Notation tutorial

### DIFF
--- a/README.md
+++ b/README.md
@@ -985,9 +985,8 @@ All the translations for this repo will be listed below:
 
 ### Videos
 
-- 🎥 [JavaScript: Intro to Big O Notation and Function Runtime — Eric Traub](https://www.youtube.com/watch?v=HgA5VOFan5E)
 - 🎥 [Essential Big O for JavaScript Developers — Dave Smith](https://www.youtube.com/watch?v=KatlvCFHPRo)
-- 🎥 [Big O Notation - Time Complexity Analysis — WebTunings](https://www.youtube.com/watch?v=ALl86xJiTD8)
+- 🎥 [JavaScript Algorithms Crash Course - Learn Algorithms & "Big O" from the Ground Up!](https://www.youtube.com/watch?v=JgWm6sQwS_I&t=2388s)
 
 **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
Some of the links are no longer active, I was able to discover two of such links and removed them. In addition, I added a new Big O Notation tutorial