### PR TITLE
Add Marathi Translation

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All the translations for this repo will be listed below:
 - [Беларуская мова (Belarussian)](https://github.com/Yafimau/33-js-concepts) — Dzianis Yafimau
 - [O'zbekcha (Uzbek)](https://github.com/smnv-shokh/33-js-concepts) — Shokhrukh Usmonov
 - [Urdu (اردو)](https://github.com/yasir2002/33-js-concepts) — Yasir Nawaz
+- [Marathi (मराठी)](https://github.com/dhruvchandak30/33-js-concepts) - Dhruv Chandak
 
 ---
 


### PR DESCRIPTION
I have added the Marathi translation.
Marathi is a language widely spoken in parts of India.
@leonardomso  Can you please review and merge it.
fixes: #376 