### PR TITLE
Added DOM from MDN for Hacktoberfest 

### DIFF
--- a/README.md
+++ b/README.md
@@ -464,6 +464,10 @@ All the translations for this repo will be listed below:
 
 ## 13. DOM and Layout Trees
 
+### Reference
+
+- [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+
 ### Books
 
 -  [Eloquent JavaScript, 3rd Edition: Ch. 14 - The Document Object Model](https://eloquentjavascript.net/14_dom.html)

--- a/README.md
+++ b/README.md
@@ -466,7 +466,7 @@ All the translations for this repo will be listed below:
 
 ### Reference
 
-- [Document Object Model (DOM)](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
+- [Document Object Model (DOM) — MDN](https://developer.mozilla.org/en-US/docs/Web/API/Document_Object_Model)
 
 ### Books
 


### PR DESCRIPTION
Added an introduction to the Document Object Model (DOM) from MDN Web Docs. This section provides an overview of how the DOM  represents the structure of HTML and XML documents.

Thank you