### PR TITLE
Add async/await video link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1017,6 +1017,7 @@ All the translations for this repo will be listed below:
 - [Tips for using async/await in JavaScript — James Q Quick](https://www.youtube.com/watch?v=_9vgd9XKlDQ)
 - [JavaScript Async Await — Web Dev Simplified](https://www.youtube.com/watch?v=V_Kr9OSfDeU)
 - [Promise async and await in javascript — Hitesh Choudhary](https://youtu.be/Gjbr21JLfgg?si=SDCVKr9ONw2GsNdT)
+- [Mastering Async/Await in JavaScript: Simplifying Asynchronous Code — Curious Rachit](https://youtu.be/dBC52AzQuCg)
 
 **[⬆ Back to Top](#table-of-contents)**
 


### PR DESCRIPTION
## Summary
This pull request aims to add a link to my upcoming YouTube video titled "Async/Await Deep Dive: Boost Your Asynchronous JavaScript Skills" to the existing async/await resources in the README. This video will cover key concepts of async/await, practical applications, and common pitfalls.

## Changes Made
- Added the following link to the README under the async/await section:
  - [Async/Await Deep Dive: Boost Your Asynchronous JavaScript Skills](https://www.youtube.com/your-video-link) - This video will go live on October 13th.

## Note
The link provided will direct to my video once it is published on October 13th. I understand that the link will not be functional until that date, but I believe this resource will enhance the existing documentation and benefit users looking to deepen their understanding of async/await in JavaScript.

Please let me know if you have any questions or if further changes are needed.
fixed #510 
![Screenshot (384)](https://github.com/user-attachments/assets/76371d3b-a114-44c0-a1e6-5500e121e5fa)
