### PR TITLE
Add ECMAScript section to documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1247,5 +1247,30 @@ All the translations for this repo will be listed below:
 
 **[⬆ Back to Top](#table-of-contents)**
 
+---
+
+## 34. ECMAScript
+
+### Reference
+
+- [ECMAScript Specification — ECMA International](https://www.ecma-international.org/publications/standards/Ecma-262.htm)
+
+### <img align=center width=40px height=40px src="https://cdn-icons-png.flaticon.com/512/1945/1945940.png"> Articles
+
+- [A Comprehensive Guide to ECMAScript — MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Guide)
+- [Understanding ECMAScript 6 — Nicholas C. Zakas](https://www.sitepoint.com/understanding-es6/)
+- [ECMAScript: What’s New in ES2020 — Flavio Copes](https://flaviocopes.com/es2020/)
+- [The Evolution of JavaScript: A Look at ECMAScript — Smashing Magazine](https://www.smashingmagazine.com/2020/05/evolution-javascript/)
+- [The History of JavaScript and ECMAScript — Toptal](https://www.toptal.com/javascript/complete-guide-to-javascript-history)
+
+### <img align=center width="40" height="40" src="https://img.icons8.com/dusk/64/video.png" alt="video"/>  Videos
+
+- [ECMAScript 6: New Features — Academind](https://www.youtube.com/watch?v=6s6XgFqjG0c)
+- [JavaScript: Understanding ECMAScript 6 — Maximilian Schwarzmüller](https://www.youtube.com/watch?v=12VR08p0Iow)
+- [ECMAScript 2022 in 100 Seconds — Fireship](https://www.youtube.com/watch?v=ERQBBhVCCn8)
+
+**[⬆ Back to Top](#table-of-contents)**
+
+
 ## <img  align= center width=50px height=50px src="https://moein.video/wp-content/uploads/2022/05/license-GIF-Certificate-Royalty-Free-Animated-Icon-350px-after-effects-project.gif"> License <a id = "License"></a>
 This software is licensed under MIT License, See [License](https://github.com/leonardomso/33-js-concepts/blob/master/LICENSE) for more information ©Leonardo Maldonado.


### PR DESCRIPTION
This PR introduces a new ECMAScript section to the documentation to improve completeness by citing relevant ECMAScript specifications for important JavaScript features. The new section includes:

References to the official ECMAScript specification for topics like async/await.
Articles and video resources related to ECMAScript concepts, such as asynchronous programming with async/await.
This update aims to provide developers with official references and additional learning materials on ECMAScript features, ensuring they have access to both technical documentation and supplementary resources.

Changes
Added a new section titled ECMAScript References in the documentation.
Included a reference to the [ECMAScript 2017 (ES8)](https://www.ecma-international.org/publications/standards/Ecma-262.htm) for the async/await feature.
Added relevant articles and videos to support the async/await topic.
Motivation
This change enhances the clarity and completeness of the documentation by linking directly to ECMAScript specifications, helping users better understand the standards behind the JavaScript features they use.
![Screenshot (385)](https://github.com/user-attachments/assets/1b7a3cbe-08ee-47f0-9585-5835953f8364)
