### PR TITLE
Remove duplicate link in call stack

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,6 @@ According to the ECMAScript specification, the call stack is defined as part of 
 -  [What is the JS Event Loop and Call Stack? — Jess Telford](https://gist.github.com/jesstelford/9a35d20a2aa044df8bf241e00d7bc2d0)
 -  [Understanding Execution Context and Execution Stack in Javascript — Sukhjinder Arora](https://blog.bitsrc.io/understanding-execution-context-and-execution-stack-in-javascript-1c9ea8642dd0)
 -  [How JavaScript Works Under The Hood: An Overview of JavaScript Engine, Heap and, Call Stack — Bipin Rajbhar](https://dev.to/bipinrajbhar/how-javascript-works-under-the-hood-an-overview-of-javascript-engine-heap-and-call-stack-1j5o)
--  [The JS Call stack Explained in 9 minutes](https://www.youtube.com/watch?v=W8AeMrVtFLY) - Colt Steel (YouTube)
 -  [Call Stack in JavaScript - Syed Rafsan Raiyan](https://srafsan.hashnode.dev/call-stack-in-javascript)
 
 ### <img align=center width="40" height="40" src="https://img.icons8.com/dusk/64/video.png" alt="video"/>  Videos


### PR DESCRIPTION
Found duplicate links in the [Call Stack section](https://github.com/leonardomso/33-js-concepts/blob/master/README.md#1-call-stack)
- [The JS Call stack Explained in 9 minutes](https://www.youtube.com/watch?v=W8AeMrVtFLY) - Colt Steel (YouTube)

So removed the first one and kept the link in the [videos section](https://github.com/leonardomso/33-js-concepts/blob/master/README.md#--videos).