### PR TITLE
Added the new article under Value Types and Reference Types

### DIFF
--- a/README.md
+++ b/README.md
@@ -185,6 +185,7 @@ All the translations for this repo will be listed below:
 -  [JavaScript Primitive vs Reference Values](http://www.javascripttutorial.net/javascript-primitive-vs-reference-values/)
 -  [JavaScript by Reference vs. by Value — nrabinowitz](https://stackoverflow.com/questions/6605640/javascript-by-reference-vs-by-value)
 -  [JavaScript Interview Prep: Primitive vs. Reference Types — Mike Cronin](https://dev.to/mostlyfocusedmike/javascript-interview-prep-primitive-vs-reference-types-3o4f)
+-  [JavaScript Primitive Values vs Reference Values - German Cocca](https://www.freecodecamp.org/news/javascript-assigning-values-vs-assigning-references/)
 -  [forEach method in JavaScript - A Comprehensive Guide](https://robiul.dev/foreach-method-in-javascript-a-comprehensive-guide)
 -  [JavaScript map vs. forEach: When to Use Each One - Sajal Soni](https://code.tutsplus.com/tutorials/javascript-map-vs-foreach-when-to-use-each-one--cms-38365)
 


### PR DESCRIPTION
Added a new article on Primitive Values vs Reference Values from freeCodeCamp to the repository. This provides a clear explanation of the differences between these two data types in JavaScript with examples.