### PR TITLE
Fix README alignment for translation names (Issue #583)

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,48 +30,48 @@ Feel free to submit a PR by adding a link to your own recaps or reviews. If you 
 
 All the translations for this repo will be listed below:
 
-- [اَلْعَرَبِيَّةُ‎ (Arabic)](https://github.com/amrsekilly/33-js-concepts) — Amr Elsekilly
-- [Български (Bulgarian)](https://github.com/thewebmasterp/33-js-concepts) - thewebmasterp
-- [汉语 (Chinese)](https://github.com/stephentian/33-js-concepts) — Re Tian
-- [Português do Brasil (Brazilian Portuguese)](https://github.com/tiagoboeing/33-js-concepts) — Tiago Boeing
-- [한국어 (Korean)](https://github.com/yjs03057/33-js-concepts.git) — Suin Lee
-- [Español (Spanish)](https://github.com/adonismendozaperez/33-js-conceptos) — Adonis Mendoza
-- [Türkçe (Turkish)](https://github.com/ilker0/33-js-concepts) — İlker Demir
-- [русский язык (Russian)](https://github.com/gumennii/33-js-concepts) — Mihail Gumennii
-- [Tiếng Việt (Vietnamese)](https://github.com/nguyentranchung/33-js-concepts) — Nguyễn Trần Chung
-- [Polski (Polish)](https://github.com/lip3k/33-js-concepts) — Dawid Lipinski
-- [فارسی (Persian)](https://github.com/majidalavizadeh/33-js-concepts) — Majid Alavizadeh
-- [Bahasa Indonesia (Indonesian)](https://github.com/rijdz/33-js-concepts) — Rijdzuan Sampoerna
-- [Français (French)](https://github.com/robinmetral/33-concepts-js) — Robin Métral
-- [हिन्दी (Hindi)](https://github.com/vikaschauhan/33-js-concepts) — Vikas Chauhan
-- [Ελληνικά (Greek)](https://github.com/DimitrisZx/33-js-concepts) — Dimitris Zarachanis
-- [日本語 (Japanese)](https://github.com/oimo23/33-js-concepts) — oimo23
-- [Deutsch (German)](https://github.com/burhannn/33-js-concepts) — burhannn
-- [украї́нська мо́ва (Ukrainian)](https://github.com/AndrewSavetchuk/33-js-concepts-ukrainian-translation) — Andrew Savetchuk
-- [සිංහල (Sinhala)](https://github.com/ududsha/33-js-concepts) — Udaya Shamendra
-- [Italiano (Italian)](https://github.com/Donearm/33-js-concepts) — Gianluca Fiore
-- [Latviešu (Latvian)](https://github.com/ANormalStick/33-js-concepts) - Jānis Īvāns
-- [Afaan Oromoo (Oromo)](https://github.com/Amandagne/33-js-concepts) - Amanuel Dagnachew
-- [ภาษาไทย (Thai)](https://github.com/ninearif/33-js-concepts) — Arif Waram
-- [Català (Catalan)](https://github.com/marioestradaf/33-js-concepts) — Mario Estrada
-- [Svenska (Swedish)](https://github.com/FenixHongell/33-js-concepts/) — Fenix Hongell
-- [ខ្មែរ (Khmer)](https://github.com/Chhunneng/33-js-concepts) — Chrea Chanchhunneng
-- [አማርኛ (Ethiopian)](https://github.com/hmhard/33-js-concepts) - Miniyahil Kebede(ምንያህል ከበደ)
-- [Беларуская мова (Belarussian)](https://github.com/Yafimau/33-js-concepts) — Dzianis Yafimau
-- [O'zbekcha (Uzbek)](https://github.com/smnv-shokh/33-js-concepts) — Shokhrukh Usmonov
-- [Urdu (اردو)](https://github.com/sudoyasir/33-js-concepts) — Yasir Nawaz
-- [हिन्दी (Hindi)](https://github.com/milostivyy/33-js-concepts) — Mahima Chauhan
-- [বাংলা (Bengali)](https://github.com/Jisan-mia/33-js-concepts) — Jisan Mia
-- [ગુજરાતી (Gujarati)](https://github.com/VatsalBhuva11/33-js-concepts) — Vatsal Bhuva
-- [سنڌي (Sindhi)](https://github.com/Sunny-unik/33-js-concepts) — Sunny Gandhwani
-- [भोजपुरी (Bhojpuri)](https://github.com/debnath003/33-js-concepts) — Pronay Debnath
-- [ਪੰਜਾਬੀ (Punjabi)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
-- [Latin (Latin)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
-- [മലയാളം (Malayalam)](https://github.com/Stark-Akshay/33-js-concepts) — Akshay Manoj
-- [Yorùbá (Yoruba)](https://github.com/ayobaj/33-js-concepts) - Ayomide Bajulaye
-- [עברית‎ (Hebrew)](https://github.com/rafyzg/33-js-concepts) — Refael Yzgea
-- [Nederlands (Dutch)](https://github.com/dlvisser/33-js-concepts) — Dave Visser
-- [தமிழ் (Tamil)] (https://github.com/UdayaKrishnanM/33-js-concepts) - Udaya Krishnan M
+- &#8206;[اَلْعَرَبِيَّةُ‎ (Arabic)](https://github.com/amrsekilly/33-js-concepts) — Amr Elsekilly
+- &#8206;[Български (Bulgarian)](https://github.com/thewebmasterp/33-js-concepts) - thewebmasterp
+- &#8206;[汉语 (Chinese)](https://github.com/stephentian/33-js-concepts) — Re Tian
+- &#8206;[Português do Brasil (Brazilian Portuguese)](https://github.com/tiagoboeing/33-js-concepts) — Tiago Boeing
+- &#8206;[한국어 (Korean)](https://github.com/yjs03057/33-js-concepts.git) — Suin Lee
+- &#8206;[Español (Spanish)](https://github.com/adonismendozaperez/33-js-conceptos) — Adonis Mendoza
+- &#8206;[Türkçe (Turkish)](https://github.com/ilker0/33-js-concepts) — İlker Demir
+- &#8206;[русский язык (Russian)](https://github.com/gumennii/33-js-concepts) — Mihail Gumennii
+- &#8206;[Tiếng Việt (Vietnamese)](https://github.com/nguyentranchung/33-js-concepts) — Nguyễn Trần Chung
+- &#8206;[Polski (Polish)](https://github.com/lip3k/33-js-concepts) — Dawid Lipinski
+- &#8206;[فارسی (Persian)](https://github.com/majidalavizadeh/33-js-concepts) — Majid Alavizadeh
+- &#8206;[Bahasa Indonesia (Indonesian)](https://github.com/rijdz/33-js-concepts) — Rijdzuan Sampoerna
+- &#8206;[Français (French)](https://github.com/robinmetral/33-concepts-js) — Robin Métral
+- &#8206;[हिन्दी (Hindi)](https://github.com/vikaschauhan/33-js-concepts) — Vikas Chauhan
+- &#8206;[Ελληνικά (Greek)](https://github.com/DimitrisZx/33-js-concepts) — Dimitris Zarachanis
+- &#8206;[日本語 (Japanese)](https://github.com/oimo23/33-js-concepts) — oimo23
+- &#8206;[Deutsch (German)](https://github.com/burhannn/33-js-concepts) — burhannn
+- &#8206;[украї́нська мо́ва (Ukrainian)](https://github.com/AndrewSavetchuk/33-js-concepts-ukrainian-translation) — Andrew Savetchuk
+- &#8206;[සිංහල (Sinhala)](https://github.com/ududsha/33-js-concepts) — Udaya Shamendra
+- &#8206;[Italiano (Italian)](https://github.com/Donearm/33-js-concepts) — Gianluca Fiore
+- &#8206;[Latviešu (Latvian)](https://github.com/ANormalStick/33-js-concepts) - Jānis Īvāns
+- &#8206;[Afaan Oromoo (Oromo)](https://github.com/Amandagne/33-js-concepts) - Amanuel Dagnachew
+- &#8206;[ภาษาไทย (Thai)](https://github.com/ninearif/33-js-concepts) — Arif Waram
+- &#8206;[Català (Catalan)](https://github.com/marioestradaf/33-js-concepts) — Mario Estrada
+- &#8206;[Svenska (Swedish)](https://github.com/FenixHongell/33-js-concepts/) — Fenix Hongell
+- &#8206;[ខ្មែរ (Khmer)](https://github.com/Chhunneng/33-js-concepts) — Chrea Chanchhunneng
+- &#8206;[አማርኛ (Ethiopian)](https://github.com/hmhard/33-js-concepts) - Miniyahil Kebede(ምንያህል ከበደ)
+- &#8206;[Беларуская мова (Belarussian)](https://github.com/Yafimau/33-js-concepts) — Dzianis Yafau
+- &#8206;[O'zbekcha (Uzbek)](https://github.com/smnv-shokh/33-js-concepts) — Shokhrukh Usmonov
+- &#8206;[Urdu (اردو)](https://github.com/sudoyasir/33-js-concepts) — Yasir Nawaz
+- &#8206;[हिन्दी (Hindi)](https://github.com/milostivyy/33-js-concepts) — Mahima Chauhan
+- &#8206;[বাংলা (Bengali)](https://github.com/Jisan-mia/33-js-concepts) — Jisan Mia
+- &#8206;[ગુજરાતી (Gujarati)](https://github.com/VatsalBhuva11/33-js-concepts) — Vatsal Bhuva
+- &#8206;[سنڌي (Sindhi)](https://github.com/Sunny-unik/33-js-concepts) — Sunny Gandhwani
+- &#8206;[भोजपुरी (Bhojpuri)](https://github.com/debnath003/33-js-concepts) — Pronay Debnath
+- &#8206;[ਪੰਜਾਬੀ (Punjabi)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
+- &#8206;[Latin (Latin)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
+- &#8206;[മലയാളം (Malayalam)](https://github.com/Stark-Akshay/33-js-concepts) — Akshay Manoj
+- &#8206;[Yorùbá (Yoruba)](https://github.com/ayobaj/33-js-concepts) - Ayomide Bajulaye
+- &#8206;[עברית‎ (Hebrew)](https://github.com/rafyzg/33-js-concepts) — Refael Yzgea
+- &#8206;[Nederlands (Dutch)](https://github.com/dlvisser/33-js-concepts) — Dave Visser
+- &#8206;[தமிழ் (Tamil)](https://github.com/UdayaKrishnanM/33-js-concepts) - Udaya Krishnan M
 
 <hr>
 


### PR DESCRIPTION
Issue #583: Some translation names in the README appear right-aligned due to RTL scripts (e.g., Arabic, Urdu, Hebrew). Adding a Left-to-Right mark (&#8206;) before each item will fix alignment and make the list consistent.