### PR TITLE
Revise translation links in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,48 +30,52 @@ Feel free to submit a PR by adding a link to your own recaps or reviews. If you 
 
 All the translations for this repo will be listed below:
 
-- [اَلْعَرَبِيَّةُ‎ (Arabic)](https://github.com/amrsekilly/33-js-concepts) — Amr Elsekilly
-- [Български (Bulgarian)](https://github.com/thewebmasterp/33-js-concepts) - thewebmasterp
-- [汉语 (Chinese)](https://github.com/stephentian/33-js-concepts) — Re Tian
-- [Português do Brasil (Brazilian Portuguese)](https://github.com/tiagoboeing/33-js-concepts) — Tiago Boeing
-- [한국어 (Korean)](https://github.com/yjs03057/33-js-concepts.git) — Suin Lee
-- [Español (Spanish)](https://github.com/adonismendozaperez/33-js-conceptos) — Adonis Mendoza
-- [Türkçe (Turkish)](https://github.com/ilker0/33-js-concepts) — İlker Demir
-- [русский язык (Russian)](https://github.com/gumennii/33-js-concepts) — Mihail Gumennii
-- [Tiếng Việt (Vietnamese)](https://github.com/nguyentranchung/33-js-concepts) — Nguyễn Trần Chung
-- [Polski (Polish)](https://github.com/lip3k/33-js-concepts) — Dawid Lipinski
-- [فارسی (Persian)](https://github.com/majidalavizadeh/33-js-concepts) — Majid Alavizadeh
-- [Bahasa Indonesia (Indonesian)](https://github.com/rijdz/33-js-concepts) — Rijdzuan Sampoerna
-- [Français (French)](https://github.com/robinmetral/33-concepts-js) — Robin Métral
-- [हिन्दी (Hindi)](https://github.com/vikaschauhan/33-js-concepts) — Vikas Chauhan
-- [Ελληνικά (Greek)](https://github.com/DimitrisZx/33-js-concepts) — Dimitris Zarachanis
-- [日本語 (Japanese)](https://github.com/oimo23/33-js-concepts) — oimo23
-- [Deutsch (German)](https://github.com/burhannn/33-js-concepts) — burhannn
-- [украї́нська мо́ва (Ukrainian)](https://github.com/AndrewSavetchuk/33-js-concepts-ukrainian-translation) — Andrew Savetchuk
-- [සිංහල (Sinhala)](https://github.com/ududsha/33-js-concepts) — Udaya Shamendra
-- [Italiano (Italian)](https://github.com/Donearm/33-js-concepts) — Gianluca Fiore
-- [Latviešu (Latvian)](https://github.com/ANormalStick/33-js-concepts) - Jānis Īvāns
-- [Afaan Oromoo (Oromo)](https://github.com/Amandagne/33-js-concepts) - Amanuel Dagnachew
-- [ภาษาไทย (Thai)](https://github.com/ninearif/33-js-concepts) — Arif Waram
-- [Català (Catalan)](https://github.com/marioestradaf/33-js-concepts) — Mario Estrada
-- [Svenska (Swedish)](https://github.com/FenixHongell/33-js-concepts/) — Fenix Hongell
-- [ខ្មែរ (Khmer)](https://github.com/Chhunneng/33-js-concepts) — Chrea Chanchhunneng
-- [አማርኛ (Ethiopian)](https://github.com/hmhard/33-js-concepts) - Miniyahil Kebede(ምንያህል ከበደ)
-- [Беларуская мова (Belarussian)](https://github.com/Yafimau/33-js-concepts) — Dzianis Yafimau
-- [O'zbekcha (Uzbek)](https://github.com/smnv-shokh/33-js-concepts) — Shokhrukh Usmonov
-- [Urdu (اردو)](https://github.com/sudoyasir/33-js-concepts) — Yasir Nawaz
-- [हिन्दी (Hindi)](https://github.com/milostivyy/33-js-concepts) — Mahima Chauhan
-- [বাংলা (Bengali)](https://github.com/Jisan-mia/33-js-concepts) — Jisan Mia
-- [ગુજરાતી (Gujarati)](https://github.com/VatsalBhuva11/33-js-concepts) — Vatsal Bhuva
-- [سنڌي (Sindhi)](https://github.com/Sunny-unik/33-js-concepts) — Sunny Gandhwani
-- [भोजपुरी (Bhojpuri)](https://github.com/debnath003/33-js-concepts) — Pronay Debnath
-- [ਪੰਜਾਬੀ (Punjabi)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
-- [Latin (Latin)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak
-- [മലയാളം (Malayalam)](https://github.com/Stark-Akshay/33-js-concepts) — Akshay Manoj
-- [Yorùbá (Yoruba)](https://github.com/ayobaj/33-js-concepts) - Ayomide Bajulaye
-- [עברית‎ (Hebrew)](https://github.com/rafyzg/33-js-concepts) — Refael Yzgea
-- [Nederlands (Dutch)](https://github.com/dlvisser/33-js-concepts) — Dave Visser
-- [தமிழ் (Tamil)] (https://github.com/UdayaKrishnanM/33-js-concepts) - Udaya Krishnan M
+<ul dir="ltr">
+
+<li>[اَلْعَرَبِيَّةُ‎ (Arabic)](https://github.com/amrsekilly/33-js-concepts) — Amr Elsekilly</li>
+<li>[Български (Bulgarian)](https://github.com/thewebmasterp/33-js-concepts) - thewebmasterp</li>
+<li>[汉语 (Chinese)](https://github.com/stephentian/33-js-concepts) — Re Tian</li>
+<li>[Português do Brasil (Brazilian Portuguese)](https://github.com/tiagoboeing/33-js-concepts) — Tiago Boeing</li>
+<li>[한국어 (Korean)](https://github.com/yjs03057/33-js-concepts.git) — Suin Lee</li>
+<li>[Español (Spanish)](https://github.com/adonismendozaperez/33-js-conceptos) — Adonis Mendoza</li>
+<li>[Türkçe (Turkish)](https://github.com/ilker0/33-js-concepts) — İlker Demir</li>
+<li>[русский язык (Russian)](https://github.com/gumennii/33-js-concepts) — Mihail Gumennii</li>
+<li>[Tiếng Việt (Vietnamese)](https://github.com/nguyentranchung/33-js-concepts) — Nguyễn Trần Chung</li>
+<li>[Polski (Polish)](https://github.com/lip3k/33-js-concepts) — Dawid Lipinski</li>
+<li>[فارسی (Persian)](https://github.com/majidalavizadeh/33-js-concepts) — Majid Alavizadeh</li>
+<li>[Bahasa Indonesia (Indonesian)](https://github.com/rijdz/33-js-concepts) — Rijdzuan Sampoerna</li>
+<li>[Français (French)](https://github.com/robinmetral/33-concepts-js) — Robin Métral</li>
+<li>[हिन्दी (Hindi)](https://github.com/vikaschauhan/33-js-concepts) — Vikas Chauhan</li>
+<li>[Ελληνικά (Greek)](https://github.com/DimitrisZx/33-js-concepts) — Dimitris Zarachanis</li>
+<li>[日本語 (Japanese)](https://github.com/oimo23/33-js-concepts) — oimo23</li>
+<li>[Deutsch (German)](https://github.com/burhannn/33-js-concepts) — burhannn</li>
+<li>[украї́нська мо́ва (Ukrainian)](https://github.com/AndrewSavetchuk/33-js-concepts-ukrainian-translation) — Andrew Savetchuk</li>
+<li>[සිංහල (Sinhala)](https://github.com/ududsha/33-js-concepts) — Udaya Shamendra</li>
+<li>[Italiano (Italian)](https://github.com/Donearm/33-js-concepts) — Gianluca Fiore</li>
+<li>[Latviešu (Latvian)](https://github.com/ANormalStick/33-js-concepts) - Jānis Īvāns</li>
+<li>[Afaan Oromoo (Oromo)](https://github.com/Amandagne/33-js-concepts) - Amanuel Dagnachew</li>
+<li>[ภาษาไทย (Thai)](https://github.com/ninearif/33-js-concepts) — Arif Waram</li>
+<li>[Català (Catalan)](https://github.com/marioestradaf/33-js-concepts) — Mario Estrada</li>
+<li>[Svenska (Swedish)](https://github.com/FenixHongell/33-js-concepts/) — Fenix Hongell</li>
+<li>[ខ្មែរ (Khmer)](https://github.com/Chhunneng/33-js-concepts) — Chrea Chanchhunneng</li>
+<li>[አማርኛ (Ethiopian)](https://github.com/hmhard/33-js-concepts) - Miniyahil Kebede(ምንያህል ከበደ)</li>
+<li>[Беларуская мова (Belarussian)](https://github.com/Yafimau/33-js-concepts) — Dzianis Yafimau</li>
+<li>[O'zbekcha (Uzbek)](https://github.com/smnv-shokh/33-js-concepts) — Shokhrukh Usmonov</li>
+<li>[Urdu (اردو)](https://github.com/sudoyasir/33-js-concepts) — Yasir Nawaz</li>
+<li>[हिन्दी (Hindi)](https://github.com/milostivyy/33-js-concepts) — Mahima Chauhan</li>
+<li>[বাংলা (Bengali)](https://github.com/Jisan-mia/33-js-concepts) — Jisan Mia</li>
+<li>[ગુજરાતી (Gujarati)](https://github.com/VatsalBhuva11/33-js-concepts) — Vatsal Bhuva</li>
+<li>[سنڌي (Sindhi)](https://github.com/Sunny-unik/33-js-concepts) — Sunny Gandhwani</li>
+<li>[भोजपुरी (Bhojpuri)](https://github.com/debnath003/33-js-concepts) — Pronay Debnath</li>
+<li>[ਪੰਜਾਬੀ (Punjabi)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak</li>
+<li>[Latin (Latin)](https://github.com/Harshdev098/33-js-concepts) — Harsh Dev Pathak</li>
+<li>[മലയാളം (Malayalam)](https://github.com/Stark-Akshay/33-js-concepts) — Akshay Manoj</li>
+<li>[Yorùbá (Yoruba)](https://github.com/ayobaj/33-js-concepts) - Ayomide Bajulaye</li>
+<li>[עברית‎ (Hebrew)](https://github.com/rafyzg/33-js-concepts) — Refael Yzgea</li>
+<li>[Nederlands (Dutch)](https://github.com/dlvisser/33-js-concepts) — Dave Visser</li>
+<li>[தமிழ் (Tamil)](https://github.com/UdayaKrishnanM/33-js-concepts) - Udaya Krishnan M</li>
+
+</ul>
 
 <hr>
 


### PR DESCRIPTION
Updated the list of translations under the "**Community**" section in the README file to ensure accuracy and completeness:

- instead of normal markdown list format, I changed the entire section as a html list for better output instead of GitHub intervention.

<img width="377" height="461" alt="image" src="https://github.com/user-attachments/assets/6c1249b5-db40-4f95-a565-b60e063d8dd2" />
