### PR TITLE
Fix incorrect Promise wrapper example (avoid reimplementation)

### DIFF
--- a/docs/concepts/promises.mdx
+++ b/docs/concepts/promises.mdx
@@ -412,10 +412,7 @@ function loadImageCallback(url, onSuccess, onError) {
 // Promise-based wrapper
 function loadImage(url) {
   return new Promise((resolve, reject) => {
-    const img = new Image()
-    img.onload = () => resolve(img)
-    img.onerror = () => reject(new Error(`Failed to load ${url}`))
-    img.src = url
+    loadImageCallback(url, resolve, reject);
   })
 }
 


### PR DESCRIPTION
The earlier example labeled as a “Wrapping Callback-Based APIs” was misleading, it reimplemented the image loading logic instead of wrapping the existing callback-based API.