### PR TITLE
docs: sidebar order Call Stack before Scope and Closures in sidebar

### DIFF
--- a/docs/docs.json
+++ b/docs/docs.json
@@ -76,8 +76,8 @@
               "concepts/primitives-objects",
               "concepts/type-coercion",
               "concepts/equality-operators",
-              "concepts/scope-and-closures",
-              "concepts/call-stack"
+              "concepts/call-stack",
+              "concepts/scope-and-closures"
             ]
           },
           {


### PR DESCRIPTION
# Fix Fundamentals sidebar order

## Summary
Move **Call Stack** before **Scope and Closures** in `docs/docs.json`.

## Why
Improves topic flow since `Scope and Closures` references the call stack.

## Testing
- [x] Ran `npm test`
- [x] Ran `npm run docs`
- [x] Verified sidebar order locally

<img width="756" height="1025" alt="image" src="https://github.com/user-attachments/assets/b253cc6e-c971-41bd-a031-a5a8764cd307" />

