### PR TITLE
docs: clarify navigator.sendBeacon() usage

### DIFF
--- a/docs/beyond/concepts/performance-observer.mdx
+++ b/docs/beyond/concepts/performance-observer.mdx
@@ -709,6 +709,60 @@ console.log('Pending entries:', pendingEntries)
 
 ---
 
+## Deep Dive: navigator.sendBeacon()
+
+When sending analytics data, `navigator.sendBeacon()` is the recommended approach over `fetch()`. However, there are a few important details to keep in mind for reliable data delivery:
+
+### 1. Data Size Limitation
+`sendBeacon()` is designed specifically for small amounts of data. The maximum allowed payload size is **64 KiB (65,536 bytes)**. If you attempt to send a larger payload, the browser will reject it and the method will return `false`.
+
+### 2. Supported Data Types
+The `data` parameter in `sendBeacon(url, data)` accepts several specific data types:
+- `String` (including JSON strings)
+- `Blob` or `File` (useful when you need to specify a `Content-Type` like `application/json`)
+- `ArrayBuffer` or `ArrayBufferView` (for binary data)
+- `FormData`
+- `URLSearchParams`
+
+### 3. Fallback Events
+While `visibilitychange` is the most reliable event to trigger analytics in modern browsers, some older browsers (particularly older versions of iOS Safari) have issues firing it reliably. In these cases, using the `pagehide` event as a fallback is recommended.
+
+```javascript
+// Robust reporting strategy
+function sendAnalytics(metrics) {
+  // Check if we already sent to avoid duplicates
+  if (document.analyticsSent) return
+  
+  const data = JSON.stringify(metrics)
+  
+  // Ensure payload is under 64 KiB limitation
+  const payloadBlob = new Blob([data], { type: 'application/json' })
+  if (payloadBlob.size < 65536) {
+    // We can send the Blob directly
+    const success = navigator.sendBeacon('/analytics', payloadBlob)
+    if (success) {
+      document.analyticsSent = true
+    }
+  } else {
+    console.warn('Analytics payload exceeds 64 KiB limit')
+  }
+}
+
+// Recommended modern event
+document.addEventListener('visibilitychange', () => {
+  if (document.visibilityState === 'hidden') {
+    sendAnalytics({ event: 'visibilitychange' })
+  }
+})
+
+// Fallback for older browsers (e.g., old iOS Safari)
+window.addEventListener('pagehide', () => {
+  sendAnalytics({ event: 'pagehide' })
+})
+```
+
+---
+
 ## Common Mistakes
 
 ### Mistake 1: Not Using Buffered

--- a/tests/beyond/observer-apis/performance-observer/performance-observer.test.js
+++ b/tests/beyond/observer-apis/performance-observer/performance-observer.test.js
@@ -716,4 +716,98 @@ describe('Performance Observer', () => {
       expect(observerCreated).toBe(false)
     })
   })
+
+  describe('Deep Dive: navigator.sendBeacon()', () => {
+    // Source: docs/beyond/concepts/performance-observer.mdx
+    beforeEach(() => {
+      vi.stubGlobal('navigator', {
+        sendBeacon: vi.fn(() => true)
+      })
+      
+      // Mock Blob to track size accurately enough for the test
+      class MockBlob {
+        constructor(parts, options) {
+          this.parts = parts
+          this.options = options
+          // Calculate size roughly by string length for this test
+          this.size = parts.reduce((acc, part) => acc + (typeof part === 'string' ? part.length : 0), 0)
+        }
+      }
+      vi.stubGlobal('Blob', MockBlob)
+    })
+
+    afterEach(() => {
+      vi.unstubAllGlobals()
+    })
+
+    it('should respect the 64 KiB data size limitation and support Blob data type', () => {
+      let analyticsSent = false
+      const sendAnalytics = (metrics) => {
+        if (analyticsSent) return
+        
+        const data = JSON.stringify(metrics)
+        const payloadBlob = new Blob([data], { type: 'application/json' })
+        
+        if (payloadBlob.size < 65536) {
+          const success = navigator.sendBeacon('/analytics', payloadBlob)
+          if (success) {
+            analyticsSent = true
+          }
+        }
+      }
+
+      // Small payload
+      sendAnalytics({ lcp: 1200 })
+      expect(navigator.sendBeacon).toHaveBeenCalledTimes(1)
+      expect(analyticsSent).toBe(true)
+      
+      // Reset for large payload
+      analyticsSent = false
+      vi.clearAllMocks()
+      
+      // Large payload
+      const largeData = { payload: 'x'.repeat(70000) }
+      sendAnalytics(largeData)
+      expect(navigator.sendBeacon).not.toHaveBeenCalled()
+      expect(analyticsSent).toBe(false)
+    })
+
+    it('should use pagehide as a fallback event', () => {
+      const sendAnalytics = vi.fn()
+      
+      const handlers = {}
+      
+      const mockDocumentAddEventListener = (event, handler) => {
+        handlers[`document:${event}`] = handler
+      }
+      
+      const mockWindowAddEventListener = (event, handler) => {
+        handlers[`window:${event}`] = handler
+      }
+      
+      let visibilityState = 'visible'
+      
+      // Setup the event listeners from the documentation
+      mockDocumentAddEventListener('visibilitychange', () => {
+        if (visibilityState === 'hidden') {
+          sendAnalytics({ event: 'visibilitychange' })
+        }
+      })
+      
+      mockWindowAddEventListener('pagehide', () => {
+        sendAnalytics({ event: 'pagehide' })
+      })
+      
+      // Simulate visibilitychange
+      visibilityState = 'hidden'
+      if (handlers['document:visibilitychange']) handlers['document:visibilitychange']()
+      expect(sendAnalytics).toHaveBeenCalledWith({ event: 'visibilitychange' })
+      
+      // Simulate pagehide
+      if (handlers['window:pagehide']) handlers['window:pagehide']()
+      expect(sendAnalytics).toHaveBeenCalledWith({ event: 'pagehide' })
+      
+      expect(sendAnalytics).toHaveBeenCalledTimes(2)
+    })
+  })
 })


### PR DESCRIPTION
This PR addresses issue #659 by:
- Clarifying the 64 KiB data size limitation.
- Detailing supported data types like Blob and ArrayBuffer.
- Explaining when to use the \pagehide\ event as a fallback.
- Updating tests to cover the new MDX examples.

Fixes #659